### PR TITLE
Make streaming news script dependency-free

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-Building a streaming news agent with free data for economic and financial news.
+# Streaming News Agent
+
+This repository contains a simple Python script that streams headlines from several free news feeds:
+
+- Reuters RSS
+- Financial Times RSS
+- Yahoo Finance RSS
+- Investing.com RSS
+- Finnhub API
+
+The script polls each source periodically and prints any new headlines to the console.
+
+## Requirements
+
+- Python 3.8+
+- No additional Python packages are required (the script uses the standard library)
+- A Finnhub API key exported as `FINNHUB_API_KEY` in your environment if you want to include Finnhub news.
+
+## Usage
+
+```bash
+export FINNHUB_API_KEY=your_key_here  # optional
+python stream_news.py
+```
+
+The script runs continuously, polling for new headlines every minute. Press `Ctrl+C` to stop it.

--- a/stream_news.py
+++ b/stream_news.py
@@ -1,0 +1,90 @@
+import os
+import time
+import json
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime
+
+FINNHUB_API_KEY = os.getenv('FINNHUB_API_KEY')
+
+RSS_FEEDS = {
+    "Reuters": "http://feeds.reuters.com/reuters/businessNews",
+    "Financial Times": "https://www.ft.com/?format=rss",
+    "Yahoo Finance": "https://finance.yahoo.com/news/rssindex",
+    "Investing.com": "https://www.investing.com/rss/news_1.rss",
+}
+
+FINNHUB_URL = "https://finnhub.io/api/v1/news?category=general&token={}".format(
+    FINNHUB_API_KEY or ""
+)
+
+
+def fetch_url(url):
+    with urllib.request.urlopen(url) as response:
+        charset = response.headers.get_content_charset() or "utf-8"
+        return response.read().decode(charset)
+
+
+def fetch_feed(url):
+    text = fetch_url(url)
+    root = ET.fromstring(text)
+    entries = []
+    for item in root.findall(".//item"):
+        entry = {
+            "id": item.findtext("guid") or item.findtext("link"),
+            "title": item.findtext("title"),
+            "link": item.findtext("link"),
+            "published": item.findtext("pubDate"),
+        }
+        entries.append(entry)
+    return entries
+
+
+def poll_finnhub(seen):
+    if not FINNHUB_API_KEY:
+        print("FINNHUB_API_KEY not set, skipping Finnhub news")
+        return
+    try:
+        text = fetch_url(FINNHUB_URL)
+        data = json.loads(text)
+        for item in data:
+            uid = str(item.get("id") or item.get("datetime"))
+            if uid in seen:
+                continue
+            seen.add(uid)
+            ts = item.get("datetime")
+            if isinstance(ts, (int, float)):
+                ts = datetime.fromtimestamp(ts).isoformat()
+            print(f"[Finnhub {ts}] {item.get('headline')} - {item.get('url')}")
+    except Exception as exc:
+        print(f"Error fetching Finnhub news: {exc}")
+
+
+def poll_rss(name, url, seen):
+    try:
+        feed = fetch_feed(url)
+        for entry in feed:
+            uid = entry["id"]
+            if uid in seen:
+                continue
+            seen.add(uid)
+            ts = entry.get("published") or ""
+            print(f"[{name} {ts}] {entry['title']} - {entry['link']}")
+    except Exception as exc:
+        print(f"Error fetching {name} feed: {exc}")
+
+
+def main():
+    seen = set()
+    while True:
+        poll_finnhub(seen)
+        for name, url in RSS_FEEDS.items():
+            poll_rss(name, url, seen)
+        time.sleep(60)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
## Summary
- rework `stream_news.py` to use only the Python standard library
- update the README to remove dependency instructions

## Testing
- `python -m py_compile stream_news.py`
- `python stream_news.py` *(fails: network access blocked)*